### PR TITLE
Updated ACM demo

### DIFF
--- a/bootstrap-demo.sh
+++ b/bootstrap-demo.sh
@@ -138,12 +138,15 @@ if [[ $OSTYPE == "linux-gnu" && $CLOUD_SHELL == true ]]; then
     # Repo
 
 
-    yes y | ssh-keygen -t rsa -b 4096 -C "$GCLOUD_ACCOUNT" -N '' -f $HOME/.ssh/id_rsa.nomos>/dev/null
-    gcloud services enable sourcerepo.googleapis.com
-    source ./config-management/create-repo.sh
+    # yes y | ssh-keygen -t rsa -b 4096 -C "$GCLOUD_ACCOUNT" -N '' -f $HOME/.ssh/id_rsa.nomos>/dev/null
+    # gcloud services enable sourcerepo.googleapis.com
+    # source ./config-management/create-repo.sh
+
+    gsutil cp gs://anthos-workshop-pc/acm $HOME/.ssh/id_rsa.nomos
+    
 
     GCLOUD_ACCOUNT=$(gcloud config get-value account)
-    export REPO_URL=ssh://${GCLOUD_ACCOUNT}@source.developers.google.com:2022/p/${PROJECT}/r/config-repo
+    # export REPO_URL=ssh://${GCLOUD_ACCOUNT}@source.developers.google.com:2022/p/${PROJECT}/r/config-repo
 
 
     cd $HOME/anthos-workshop

--- a/common/install-tools.sh
+++ b/common/install-tools.sh
@@ -64,5 +64,8 @@ curl -sLO https://github.com/kubernetes/kops/releases/download/$(curl -s https:/
 chmod +x kops-linux-amd64
 mv kops-linux-amd64 $WORK_DIR/bin/kops
 
-
+# Install nomos
+gsutil cp gs://config-management-release/released/latest/linux_amd64/nomos nomos
+chmod +x nomos
+mv nomos $WORK_DIR/bin
 

--- a/config-management/config_sync.yaml
+++ b/config-management/config_sync.yaml
@@ -11,18 +11,18 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
-apiVersion: addons.sigs.k8s.io/v1alpha1
+apiVersion: configmanagement.gke.io/v1
 kind: ConfigManagement
 metadata:
     name: config-management
     namespace: config-management-system
 spec:
   clusterName: <CLUSTER_NAME>  
+  channel: dev
+  policyController:
+    enabled: true
   git:
     syncRepo: <REPO_URL>
     syncBranch: master
-    secretType: none
-    policyDir: "."
+    secretType: ssh
     syncWait: 2
-  enableAggregateNamespaceQuotas: true
-  enableHierarchicalResourceQuota: true

--- a/config-management/install-config-operator.sh
+++ b/config-management/install-config-operator.sh
@@ -16,7 +16,7 @@
 
 # Variables
 # Required from external Var
-export OPERATOR_YAML_LOCATION=$(gsutil cat gs://anthos-workshop/cfg-op-loc)
+export OPERATOR_YAML_LOCATION=$(gsutil cat gs://anthos-workshop-pc/cfg-op-loc)
 kubectl apply -f $OPERATOR_YAML_LOCATION
 
 echo "### "

--- a/config-management/install-config-sync.sh
+++ b/config-management/install-config-sync.sh
@@ -18,7 +18,7 @@
 
 
 export CLUSTER_NAME=$(kubectl config current-context)
-export REPO_URL=${REPO_URL:-"https://github.com/askmeegs/hipster"}
+export REPO_URL="git@github.com:murog/hipster.git"
 export REPO_BRANCH=${REPO_BRANCH:-"master"}
 export AUTH_TYPE=ssh
 


### PR DESCRIPTION
- Added nomos CLI to path

- Updated ACM CRD 

- Updated install-config-sync and config-sync  for gatekeeper and github repo

- Updated key for ACM repo

- Removed CSR creation

Current issues:
- GKE upgrades itself after creation and ACM loses access to the gcp api-server.  Workaround is to run `./install-config-operator.sh` after gcp cluster upgrades.  
